### PR TITLE
Added unapply method definition

### DIFF
--- a/src/main/scala/com/spotify/scio/ScioInjector.scala
+++ b/src/main/scala/com/spotify/scio/ScioInjector.scala
@@ -115,8 +115,8 @@ class ScioInjector extends SyntheticMembersInjector {
         // TODO: missing extends and traits - are they needed?
         // $tn extends ${p(c, SType)}.HasSchema[$name] with ..$traits
         val companion = s"""|object ${c.getName} {
-                            |  def apply( $applyPropsSignature ) : ${c.getName} = ???
-                            |  def unapply(x$$0: ${c.getName}) : Option[($unapplyReturnTypes)] = ???
+                            |  def apply( $applyPropsSignature ): ${c.getName} = ???
+                            |  def unapply(x$$0: ${c.getName}): _root_.scala.Option[($unapplyReturnTypes)] = ???
                             |  def fromTableRow: _root_.scala.Function1[_root_.com.google.api.services.bigquery.model.TableRow, ${c.getName} ] = ???
                             |  def toTableRow: _root_.scala.Function1[ ${c.getName}, _root_.com.google.api.services.bigquery.model.TableRow] = ???
                             |  def schema: _root_.com.google.api.services.bigquery.model.TableSchema = ???
@@ -138,8 +138,8 @@ class ScioInjector extends SyntheticMembersInjector {
         val unapplyReturnTypes = getUnapplyReturnTypes(caseClasses).mkString(" , ")
 
         val companion = s"""|object ${c.getName} {
-                            |  def apply( $applyPropsSignature ) : ${c.getName} = ???
-                            |  def unapply(x$$0: ${c.getName}) : Option[($unapplyReturnTypes)] = ???
+                            |  def apply( $applyPropsSignature ): ${c.getName} = ???
+                            |  def unapply(x$$0: ${c.getName}): _root_.scala.Option[($unapplyReturnTypes)] = ???
                             |  def fromGenericRecord: _root_.scala.Function1[_root_.org.apache.avro.generic.GenericRecord, ${c.getName} ] = ???
                             |  def toGenericRecord: _root_.scala.Function1[ ${c.getName}, _root_.org.apache.avro.generic.GenericRecord] = ???
                             |  def schema: _root_.org.apache.avro.Schema = ???

--- a/src/test/scala/com/spotify/scio/ScioInjectorTest.scala
+++ b/src/test/scala/com/spotify/scio/ScioInjectorTest.scala
@@ -78,4 +78,18 @@ class ScioInjectorTest extends FlatSpec with Matchers {
     si.getTupledMethod(className, input) shouldBe expected
   }
 
+
+  it should "return the unapply return types on case class with 3 parameters" in {
+    val input = Seq(s"""|case class $className(
+                        |f1 : _root_.scala.Option[_root_.java.lang.String],
+                        |f2 : _root_.scala.Option[_root_.java.lang.Long],
+                        |f2 : _root_.scala.Option[_root_.java.lang.Int])
+                        |extends _root_.com.spotify.scio.bigquery.types.BigQueryType.HasAnnotation
+                        |""".stripMargin.replace("\n"," "))
+    val expected = Seq(
+      "_root_.scala.Option[_root_.java.lang.String]",
+      "_root_.scala.Option[_root_.java.lang.Long]",
+      "_root_.scala.Option[_root_.java.lang.Int]")
+    si.getUnapplyReturnTypes(input) shouldBe expected
+  }
 }


### PR DESCRIPTION
Hi, I've noticed that Idea gets angry while I'm trying to pattern match a generated case class from `@BigQueryType.fromQuery` so I've added the `unapply` method definition.
I've also made a little refactoring introducing the ConstructorProps case class integrating the types extraction logic.