### PR TITLE
Fix for hash calculation on Windows

### DIFF
--- a/src/main/scala/com/spotify/scio/ScioInjector.scala
+++ b/src/main/scala/com/spotify/scio/ScioInjector.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio
 
+import java.io.File
 import java.nio.charset.Charset
 import java.nio.file.{Path, Paths}
 
@@ -92,7 +93,7 @@ class ScioInjector extends SyntheticMembersInjector {
   private def genHashForMacro(owner: String, srcFile: String): String = {
     Hashing.murmur3_32().newHasher()
       .putString(owner, Charsets.UTF_8)
-      .putString(srcFile, Charsets.UTF_8)
+      .putString(new File(srcFile).getCanonicalPath, Charsets.UTF_8)
       .hash().toString
   }
 

--- a/src/main/scala/com/spotify/scio/ScioInjector.scala
+++ b/src/main/scala/com/spotify/scio/ScioInjector.scala
@@ -93,7 +93,7 @@ class ScioInjector extends SyntheticMembersInjector {
   private def genHashForMacro(owner: String, srcFile: String): String = {
     Hashing.murmur3_32().newHasher()
       .putString(owner, Charsets.UTF_8)
-      .putString(new File(srcFile).getCanonicalPath, Charsets.UTF_8)
+      .putString(srcFile, Charsets.UTF_8)
       .hash().toString
   }
 
@@ -177,7 +177,9 @@ class ScioInjector extends SyntheticMembersInjector {
   private def fetchGeneratedCaseClasses(source: ScTypeDefinition, c: ScClass) = {
     // For some reason sometimes [[getVirtualFile]] returns null, use Option. I don't know why.
     val fileName = Option(c.asInstanceOf[PsiElement].getContainingFile.getVirtualFile)
-      .map(_.getCanonicalPath)
+      // wrap VirtualFile to java.io.File to use OS file separator
+      .map(vf => new File(vf.getCanonicalPath).getCanonicalPath)
+
     val hash = fileName.map(genHashForMacro(source.getTruncedQualifiedName, _))
 
     hash.flatMap(h => findClassFile(s"${c.getName}-$h.scala")).map(f => {


### PR DESCRIPTION
Fix for running scio-idea-plugin on Windows. The path in `srcFile` passed to `genHashForMacro` contains a mixture of `/` and `\` as path separators, while Scio's `TypeProvider` consistently uses the OS separator.  This results in different hashes between Scio and the IntelliJ plugin. 

Without the fix a path looks as follows on a Windows machine: **C:\Users\xy\AppData\Local\Temp\/bigquery-classes/ClassXY-687c8b87.scala**

Scio `TypeProvider`: https://github.com/spotify/scio/blob/5eb8bee4455f3b410cfd3d840ddc0f9b5f4a5b3e/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala#L318