### PR TITLE
Clean up the build file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,5 +60,6 @@ lazy val scioIdeaPlugin: Project = project
     libraryDependencies ++= Seq(
       Guava,
       Scalatest % Test
-    ),
-  ).enablePlugins(SbtIdeaPlugin)
+    )
+  )
+  .enablePlugins(SbtIdeaPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -49,25 +49,16 @@ lazy val ideaSettings = Def.settings(
   ThisBuild / intellijPluginName := "scio-idea",
   ThisBuild / intellijPlatform := IntelliJPlatform.IdeaCommunity,
   ThisBuild / intellijBuild := "203.7148.57",
-  intellijPlugins += "com.intellij.java".toPlugin,
   intellijPlugins += "org.intellij.scala".toPlugin
-)
-
-lazy val packagingSettings = Def.settings(
-  packageMethod := PackagingMethod.Standalone()
 )
 
 lazy val scioIdeaPlugin: Project = project
   .in(file("."))
   .settings(commonSettings)
   .settings(ideaSettings)
-  .settings(packagingSettings)
   .settings(
-    name := "scio-idea",
     libraryDependencies ++= Seq(
       Guava,
       Scalatest % Test
     ),
-    intellijVMOptions := intellijVMOptions.value.copy(gc = "-XX:+UseParallelGC")
-  )
-  .enablePlugins(SbtIdeaPlugin)
+  ).enablePlugins(SbtIdeaPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.9.5")
+addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.9.6")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")


### PR DESCRIPTION
- packageMethod is Standalone by default
- explicit dependency on com.intellij.java is not required
  since it's transitively loaded by org.intellij.scala
- -XX:+UseG1GC(default) is recommended over
  -XX:+UseParallelGC for JDK11
- manually setting the 'name' key is not recommended
  because it confuses the IDEA xml generator see
  JetBrains/sbt-idea-plugin#72