### PR TITLE
Build and enable plugin for newer IntelliJ versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val commonSettings = Def.settings(
 lazy val ideaSettings = Def.settings(
   ThisBuild / intellijPluginName := "scio-idea",
   ThisBuild / intellijPlatform := IntelliJPlatform.IdeaCommunity,
-  ThisBuild / intellijBuild := "203.7148.57",
+  ThisBuild / intellijBuild := "213.6461.79",
   intellijPlugins += "org.intellij.scala".toPlugin
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.13.4")
+addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.13.7")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.5")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
 
     <description>IntelliJ IDEA plugin for Scio - https://github.com/spotify/scio</description>
 
-    <idea-version since-build="203.0" until-build="203.*" />
+    <idea-version since-build="203.0" until-build="213.*" />
 
     <depends>com.intellij.modules.java</depends>
     <depends>org.intellij.scala</depends>


### PR DESCRIPTION
Bump compatible IntelliJ versions to 213.6461.79 and update
sbt-idea-plugin plugin to 3.13.7.