### PR TITLE
Use patchPluginXml

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,11 +45,18 @@ lazy val commonSettings = Def.settings(
   )
 )
 
+lazy val prePackageArtifact = taskKey[Unit]("Force doPatchPluginXml run before artifact is built")
+prePackageArtifact := Def.sequential(packageMappings, doPatchPluginXml).value
+packageArtifact := (packageArtifact dependsOn prePackageArtifact).value
+
 lazy val ideaSettings = Def.settings(
   ThisBuild / intellijPluginName := "scio-idea",
   ThisBuild / intellijPlatform := IntelliJPlatform.IdeaCommunity,
   ThisBuild / intellijBuild := "232.10072.27",
-  intellijPlugins += "org.intellij.scala".toPlugin
+  intellijPlugins += "org.intellij.scala".toPlugin,
+  patchPluginXml := pluginXmlOptions { xml =>
+    xml.version = version.value
+  }
 )
 
 lazy val scioIdeaPlugin: Project = project

--- a/build.sbt
+++ b/build.sbt
@@ -45,9 +45,8 @@ lazy val commonSettings = Def.settings(
   )
 )
 
-lazy val prePackageArtifact = taskKey[Unit]("Force doPatchPluginXml run before artifact is built")
-prePackageArtifact := Def.sequential(packageMappings, doPatchPluginXml).value
-packageArtifact := (packageArtifact dependsOn prePackageArtifact).value
+// Avoid racing doPatchPluginXml against packageMappings
+packageArtifact := (packageArtifact dependsOn Def.sequential(packageMappings, doPatchPluginXml)).value
 
 lazy val ideaSettings = Def.settings(
   ThisBuild / intellijPluginName := "scio-idea",

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,9 @@ lazy val commonSettings = Def.settings(
 )
 
 // Avoid racing doPatchPluginXml against packageMappings
-packageArtifact := (packageArtifact dependsOn Def.sequential(packageMappings, doPatchPluginXml)).value
+packageArtifact := {
+  packageArtifact dependsOn Def.sequential(packageMappings, doPatchPluginXml)
+}.value
 
 lazy val ideaSettings = Def.settings(
   ThisBuild / intellijPluginName := "scio-idea",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.spotify.scio-idea</id>
     <name>Scio IDEA</name>
-    <version>0.1.24</version>
+    <version>FILLED_BY_BUILD</version>
     <vendor url="https://github.com/spotify/scio-idea-plugin">Spotify</vendor>
 
     <description>IntelliJ IDEA plugin for Scio - https://github.com/spotify/scio</description>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
     <id>com.spotify.scio-idea</id>
     <name>Scio IDEA</name>
     <version>FILLED_BY_BUILD</version>
-    <vendor url="https://github.com/spotify/scio-idea-plugin">Spotify</vendor>
+    <vendor>Spotify</vendor>
 
     <description>IntelliJ IDEA plugin for Scio - https://github.com/spotify/scio</description>
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.24"
+ThisBuild / version := "0.1.25"


### PR DESCRIPTION
Sidesteps an issue with `sbt-idea-plugin` where the `plugin.xml` would not be updated due to a race by introducing a sequential `prePackageArtifact` task and forcing `packageArtifact` to depend upon it.

Noted by @clairemcginty [in this comment](https://github.com/spotify/scio-idea-plugin/pull/224#discussion_r792825984)