### PR TITLE
Inject Product super to generated case classes

### DIFF
--- a/src/main/scala/com/spotify/scio/AnnotationTypeInjector.scala
+++ b/src/main/scala/com/spotify/scio/AnnotationTypeInjector.scala
@@ -19,7 +19,7 @@ package com.spotify.scio
 
 import java.io.File
 import java.nio.charset.Charset
-import java.nio.file.{Paths, Files as JFiles}
+import java.nio.file.{Files as JFiles, Paths}
 import com.google.common.base.Charsets
 import com.google.common.hash.Hashing
 import com.google.common.io.Files
@@ -34,6 +34,15 @@ import scala.collection.mutable
 
 object AnnotationTypeInjector {
   private val Log = Logger.getInstance(classOf[AnnotationTypeInjector])
+
+  // case classes implement Product trait
+  val CaseClassSuper: String = "_root_.scala.Product"
+  val CaseClassFunctions: Seq[String] = Seq(
+    "def productArity: _root_.scala.Int = ???",
+    "def productElement(n: _root_.scala.Int): _root_.scala.Any = ???",
+    "def canEqual(x: _root_.scala.Any): _root_.scala.Boolean = ???"
+  )
+
   private val CaseClassArgs = """case\s+class\s+[^(]+\((.*)\).*""".r
   private val TypeArg = """[a-zA-Z0-9_$]+\s*:\s*[a-zA-Z0-9._$]+([\[(](.*?)[)\]]+)?""".r
   private val AlertEveryMissedXInvocations = 5

--- a/src/main/scala/com/spotify/scio/AvroTypeInjector.scala
+++ b/src/main/scala/com/spotify/scio/AvroTypeInjector.scala
@@ -27,6 +27,8 @@ object AvroTypeInjector {
     s"$AvroTNamespace.toSchema"
   )
   private val CaseClassSuper =
+    "_root_.scala.Product"
+  private val HasAvroAnnotationSuper =
     "_root_.com.spotify.scio.avro.types.AvroType.HasAvroAnnotation"
 
   private def avroAnnotation(sc: ScClass): Option[String] =
@@ -50,7 +52,7 @@ final class AvroTypeInjector extends AnnotationTypeInjector {
           parent = qn.init
           defs <- {
             generatedCaseClasses(parent, c)
-              .find(_.contains(CaseClassSuper))
+              .find(_.contains(HasAvroAnnotationSuper))
               .map(getApplyPropsSignature)
               .map(v => s"def $v = ???")
           }
@@ -62,7 +64,7 @@ final class AvroTypeInjector extends AnnotationTypeInjector {
 
   override def injectSupers(source: ScTypeDefinition): Seq[String] =
     source match {
-      case c: ScClass if avroAnnotation(c).isDefined => Seq(CaseClassSuper)
+      case c: ScClass if avroAnnotation(c).isDefined => Seq(CaseClassSuper, HasAvroAnnotationSuper)
       case _                                         => Seq.empty
     }
 
@@ -77,7 +79,7 @@ final class AvroTypeInjector extends AnnotationTypeInjector {
         case c: ScClass if avroAnnotation(c).isDefined =>
           val (annotated, other) =
             generatedCaseClasses(source.getQualifiedName.init, c).partition(
-              _.contains(CaseClassSuper)
+              _.contains(HasAvroAnnotationSuper)
             )
           (c, (annotated.headOption, other))
       }

--- a/src/main/scala/com/spotify/scio/BigQueryTypeInjector.scala
+++ b/src/main/scala/com/spotify/scio/BigQueryTypeInjector.scala
@@ -39,8 +39,6 @@ object BigQueryTypeInjector {
     s"$BQTNamespace.toTable"
   )
 
-  private val CaseClassSuper =
-    "_root_.scala.Product"
   private val HasAnnotationSuper =
     "_root_.com.spotify.scio.bigquery.types.BigQueryType.HasAnnotation"
 
@@ -78,14 +76,12 @@ object BigQueryTypeInjector {
     annotation match {
       case a if a.contains(FromQuery) =>
         val simple = """
-          |def query: _root_.java.lang.String = ???
           |def queryRaw: _root_.java.lang.String = ???
           |""".stripMargin
 
         bqQuerySignature(c)
           .map { params =>
             simple + s"""
-              |def query($params): _root_.java.lang.String = ???
               |def queryAsSource($params): _root_.com.spotify.scio.bigquery.Query = ???
               |""".stripMargin
           }
@@ -112,20 +108,16 @@ final class BigQueryTypeInjector extends AnnotationTypeInjector {
   override def injectFunctions(source: ScTypeDefinition): Seq[String] =
     source match {
       case c: ScClass if bqAnnotation(c).isDefined =>
-        val result = for {
-          cc <- Option(c.containingClass)
-          qn <- Option(cc.getQualifiedName)
+        val fields = for {
+          cc <- Option(c.containingClass).toSeq
+          qn <- Option(cc.getQualifiedName).toSeq
           parent = qn.init
-          defs <- {
-            generatedCaseClasses(parent, c)
-              .find(_.contains(HasAnnotationSuper))
-              .map(getApplyPropsSignature)
-              .map(v => s"def $v = ???")
-          }
-        } yield defs
-
-        result.toSeq
-      case _ => Seq.empty
+          cls <- generatedCaseClasses(parent, c).find(_.contains(HasAnnotationSuper)).toSeq
+          v <- getApplyPropsSignature(cls)
+        } yield s"def $v = ???"
+        CaseClassFunctions ++ fields
+      case _ =>
+        Seq.empty
     }
 
   override def injectSupers(source: ScTypeDefinition): Seq[String] =

--- a/src/main/scala/com/spotify/scio/BigQueryTypeInjector.scala
+++ b/src/main/scala/com/spotify/scio/BigQueryTypeInjector.scala
@@ -40,6 +40,8 @@ object BigQueryTypeInjector {
   )
 
   private val CaseClassSuper =
+    "_root_.scala.Product"
+  private val HasAnnotationSuper =
     "_root_.com.spotify.scio.bigquery.types.BigQueryType.HasAnnotation"
 
   private def bqAnnotation(sc: ScClass): Option[String] =
@@ -116,7 +118,7 @@ final class BigQueryTypeInjector extends AnnotationTypeInjector {
           parent = qn.init
           defs <- {
             generatedCaseClasses(parent, c)
-              .find(_.contains(CaseClassSuper))
+              .find(_.contains(HasAnnotationSuper))
               .map(getApplyPropsSignature)
               .map(v => s"def $v = ???")
           }
@@ -128,7 +130,7 @@ final class BigQueryTypeInjector extends AnnotationTypeInjector {
 
   override def injectSupers(source: ScTypeDefinition): Seq[String] =
     source match {
-      case c: ScClass if bqAnnotation(c).isDefined => Seq(CaseClassSuper)
+      case c: ScClass if bqAnnotation(c).isDefined => Seq(CaseClassSuper, HasAnnotationSuper)
       case _                                       => Seq.empty
     }
 
@@ -143,7 +145,7 @@ final class BigQueryTypeInjector extends AnnotationTypeInjector {
         case c: ScClass if bqAnnotation(c).isDefined =>
           val (annotated, other) =
             generatedCaseClasses(source.getQualifiedName.init, c).partition(
-              _.contains(CaseClassSuper)
+              _.contains(HasAnnotationSuper)
             )
           (c, (annotated.headOption, other))
       }


### PR DESCRIPTION
Scio 0.14 default coders for generated classes are not found by IntelliJ if the IDE does not know the classes have Product super type