### PR TITLE
Pin verifier version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,7 @@ lazy val scioIdeaPlugin: Project = project
       xml.sinceBuild = intellijBuild.value
     },
     pluginVerifierOptions := pluginVerifierOptions.value.copy(
+      version = "1.381", // newer verifiers fail
       // verify against latest IntelliJ IDEA Community
       overrideIDEs = Seq(
         intellijBaseDirectory.value.toString,


### PR DESCRIPTION
Newer versions of the verifier do not seem to correctly pull the declared dependencies from plugin.xml OR the sbt plugin is not constructing the correct incantation to the newer plugin verifier executables. The root cause is unfortunately not clear to me. Possibly related to JetBrains/intellij-plugin-verifier#1343 but the associated bug is not visible.